### PR TITLE
Poison BOOST_DESCRIBE_ENUM in class scope

### DIFF
--- a/include/boost/describe/enum.hpp
+++ b/include/boost/describe/enum.hpp
@@ -56,6 +56,7 @@ template<class... T> auto enum_descriptor_fn_impl( int, T... )
 #if defined(_MSC_VER) && !defined(__clang__)
 
 #define BOOST_DESCRIBE_ENUM(E, ...) \
+    namespace should_use_BOOST_DESCRIBE_NESTED_ENUM {} \
     static_assert(std::is_enum<E>::value, "BOOST_DESCRIBE_ENUM should only be used with enums"); \
     BOOST_DESCRIBE_ENUM_BEGIN(E) \
     BOOST_DESCRIBE_PP_FOR_EACH(BOOST_DESCRIBE_ENUM_ENTRY, E, __VA_ARGS__) \
@@ -70,6 +71,7 @@ template<class... T> auto enum_descriptor_fn_impl( int, T... )
 #else
 
 #define BOOST_DESCRIBE_ENUM(E, ...) \
+    namespace should_use_BOOST_DESCRIBE_NESTED_ENUM {} \
     static_assert(std::is_enum<E>::value, "BOOST_DESCRIBE_ENUM should only be used with enums"); \
     BOOST_DESCRIBE_MAYBE_UNUSED BOOST_DESCRIBE_ENUM_BEGIN(E) \
     BOOST_DESCRIBE_PP_FOR_EACH(BOOST_DESCRIBE_ENUM_ENTRY, E, ##__VA_ARGS__) \

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -48,6 +48,9 @@ compile test_d_type.cpp ;
 compile-fail enum_struct_fail.cpp ;
 compile-fail struct_enum_fail.cpp ;
 
+compile-fail enum_nested_fail.cpp ;
+compile-fail nested_enum_fail.cpp ;
+
 run class_template_test.cpp ;
 
 run has_enumerators_test.cpp ;

--- a/test/enum_nested_fail.cpp
+++ b/test/enum_nested_fail.cpp
@@ -1,0 +1,18 @@
+// Copyright 2021 Peter Dimov
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/describe/enum.hpp>
+
+#if !defined(BOOST_DESCRIBE_CXX14)
+
+#error "Skipping test because C++14 is not available"
+
+#else
+
+struct S1 {
+    enum E1 {};
+    BOOST_DESCRIBE_ENUM(E1);
+};
+
+#endif // !defined(BOOST_DESCRIBE_CXX14)

--- a/test/nested_enum_fail.cpp
+++ b/test/nested_enum_fail.cpp
@@ -1,0 +1,16 @@
+// Copyright 2021 Peter Dimov
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/describe/enum.hpp>
+
+#if !defined(BOOST_DESCRIBE_CXX14)
+
+#error "Skipping test because C++14 is not available"
+
+#else
+
+enum E1 {};
+BOOST_DESCRIBE_NESTED_ENUM(E1);
+
+#endif // !defined(BOOST_DESCRIBE_CXX14)


### PR DESCRIPTION
using `namespace` keyword (is there anything better that can appear at namespace scope, not at class scope)?
try to inform the user that they should use BOOST_DESCRIBE_NESTED_ENUM instead